### PR TITLE
Fix transaction_id field number in TimeSyncData

### DIFF
--- a/proto/g2_protocol.proto
+++ b/proto/g2_protocol.proto
@@ -38,7 +38,7 @@ message TimeSyncRequest {
 message TimeSyncData {
   uint32 unknown1 = 2;      // Always 17 (0x11)?
   uint64 timestamp = 1;     // Unix timestamp (varint)
-  int64 transaction_id = 2; // Usually -24 (0xFFFFFFFFFFFFFFE8)
+  int64 transaction_id = 3; // Usually -24 (0xFFFFFFFFFFFFFFE8)
 }
 
 // =============================================================================


### PR DESCRIPTION
transaction_id was assigned field number 2, which is already used by unknown1 in the same message. Protobuf requires unique field numbers within a message - this would cause a compilation error. Changed transaction_id to field number 3.